### PR TITLE
fix: PIZ-1 added endpoint to retrieve all sizes of pizzas

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_ingredients():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if size else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
Why?
This endpoint is needed in order to be able to retrieve all sizes of pizzas available

Files Modified:
- app/services/size.py
