### PR TITLE
PIZ1 - I can't create an order (Bug)

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_size():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if size else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
**Ticket link:** [PIZ-1 Ticket](https://trello.com/c/s7KFDYue/1-piz1-i-cant-create-an-order-bug)

**Description:** There was a bug where the list of sizes that the client defines is not shown in the homepage. Under further investigation we saw that a 405 (Method Not Allowed) issue raised. The solution was to develop the missing service to GET a list of all available sizes. 

**Test scenarios:** Once the backend is running. The endpoint [http://127.0.0.1:5000/size/](http://127.0.0.1:5000/size/) can be access to see all the sizes. 