### PR TITLE
PIZ1- I can't create an order (BUG)

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_size():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
Ticket link: [PIZ-1](https://trello.com/c/9US81Jzi/1-piz1-i-cant-create-an-order-bug)
Description:
Found a BUG that does not allow the user to see the sizes created and pick size when creating and ordering a pizza. The bug occurs due to a 405 Error when calling a service that has not been implemented yet that retrieves all the sizes from the endpoint. As a solution, we implement the missing service that obtains all sizes through GET. After that we can see sizes and create orders!

Tests:
By accessing the endpoint we get all sizes created.

Screenshots:
![image](https://github.com/ioet/python-pizza-planet/assets/99340694/906e36e8-c604-48f4-9097-57d4e1091280)
![image](https://github.com/ioet/python-pizza-planet/assets/99340694/2ab29718-49d7-4069-abcb-4990ab7dbba8)


