### PR TITLE
PIZ-1: Cant Create Order Found Bug Error

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_size():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_sizes.py
+++ b/app/test/services/test_sizes.py
@@ -1,0 +1,15 @@
+import pytest
+
+def test_create_size_service(create_size):
+    size = create_size.json
+    pytest.assume(create_size.status.startswith('200'))
+    pytest.assume(size['_id'])
+    pytest.assume(size['name'])
+    pytest.assume(size['price'])
+
+def test_get_ingredients_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {size['_id']: size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
Ticket link: [PIZ-1](https://trello.com/c/9US81Jzi/1-piz1-i-cant-create-an-order-bug)
Description:
Found a BUG that does not allow the user to see the sizes created and pick size when creating and ordering a pizza. The bug occurs due to a 405 Error when calling a service that has not been implemented yet that retrieves all the sizes from the endpoint. As a solution, we implement the missing service that obtains all sizes through GET. After that we can see sizes and create orders!

Tests:
By accessing the endpoint we get all sizes created.

Screenshots:
![image](https://github.com/ioet/python-pizza-planet/assets/99340694/906e36e8-c604-48f4-9097-57d4e1091280)
![image](https://github.com/ioet/python-pizza-planet/assets/99340694/2ab29718-49d7-4069-abcb-4990ab7dbba8)
